### PR TITLE
Fixes "Too many open files"

### DIFF
--- a/src/ProjectInfinity/ReportRTS/persistence/MySQLDataProvider.php
+++ b/src/ProjectInfinity/ReportRTS/persistence/MySQLDataProvider.php
@@ -36,9 +36,11 @@ class MySQLDataProvider implements DataProvider {
         # Set up tickets table.
         $resource = $this->plugin->getResource("mysql_tickets.sql");
         $this->database->query(stream_get_contents($resource));
+        fclose($resource);
         # Set up users table.
         $resource = $this->plugin->getResource("mysql_users.sql");
         $this->database->query(stream_get_contents($resource));
+        fclose($resource);
 
         # Make sure connection stays alive.
         $this->plugin->getServer()->getScheduler()->scheduleRepeatingTask(new MySQLKeepAliveTask($this->plugin, $this->database), 600);


### PR DESCRIPTION
This fixes issues with not closing resources given by PocketMine, causing a crash at a later stage.
Users usually blame PocketMine for this, but it's entirely a plugin's fault.

This code was found via GitHub search, please review your code for usage of:

* `Plugin->getResource()` without `fclose()` calls later
* Not needed `Plugin->getResource()` calls
* `fopen()` calls without `fclose()`
* `popen()` calls without `pclose()`